### PR TITLE
Include shop styling and scripts in landing page

### DIFF
--- a/templates/landingpage/design.js
+++ b/templates/landingpage/design.js
@@ -1,4 +1,6 @@
 require('./styles/styles.scss');
+require('../../shop-styling.css');
+require('../../shop-scripts.js');
 
 const {cx, SchemaVersion, Locale} = require('@bsi-cx/design-build');
 


### PR DESCRIPTION
## Summary
- require shop CSS and scripts in landingpage design module

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:dev` *(fails: webpack: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5be0ee7f4832e8865b60643ff24e4