### PR TITLE
feat: add shop content element

### DIFF
--- a/templates/landingpage/content-elements/shop/index.js
+++ b/templates/landingpage/content-elements/shop/index.js
@@ -1,0 +1,6 @@
+const {cx} = require('@bsi-cx/design-build');
+
+module.exports = cx.contentElement
+  .withId('shop')
+  .withLabel('Shop')
+  .withTemplate(require('./template.twig'));

--- a/templates/landingpage/design.js
+++ b/templates/landingpage/design.js
@@ -58,7 +58,8 @@ module.exports = cx.design
         require('@bsi-cx/design-standard-library-web/content-elements/advanced/webcam-image-upload'),
         require('@bsi-cx/design-standard-library-web/content-elements/base/slot-finder'),
         require('@bsi-cx/design-standard-library-web/content-elements/base/chart'),
-        require('@bsi-cx/design-standard-library-web/content-elements/base/html')),
+        require('@bsi-cx/design-standard-library-web/content-elements/base/html'),
+        require('./content-elements/shop')),
     cx.contentElementGroup
       .withGroupId('forms-NjbmnQ')
       /*.withLabel('Forms')*/


### PR DESCRIPTION
## Summary
- add registration for shop content element
- expose shop element in landing page design

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a5c0f436b0832e961a3fa262c8f7a9