### PR TITLE
Add DOM availability guard to shop scripts

### DIFF
--- a/shop-scripts.js
+++ b/shop-scripts.js
@@ -1,3 +1,4 @@
+if (typeof document !== 'undefined') {
 document.addEventListener('DOMContentLoaded', () => {
 
     var totalPointsAvailable = 20; // Gesamtpunktzahl, die der Nutzer ausgeben darf
@@ -369,3 +370,4 @@ window.scrollTo(0, 0);
     }
 
 }); // Ende DOMContentLoaded
+}


### PR DESCRIPTION
## Summary
- Guard `shop-scripts.js` with a `typeof document !== 'undefined'` check so code only runs in browser environments

## Testing
- `node shop-scripts.js && echo "success"`
- `npm run build:dev` *(fails: sh: 1: webpack: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c460ccd0832e9974a83b31e0e0f8