### PR TITLE
Fix shop content element to use elementId and file reference

### DIFF
--- a/templates/landingpage/content-elements/shop/index.js
+++ b/templates/landingpage/content-elements/shop/index.js
@@ -1,6 +1,6 @@
 const {cx} = require('@bsi-cx/design-build');
 
 module.exports = cx.contentElement
-  .withId('shop')
+  .withElementId('shop-UEyFnQ')
   .withLabel('Shop')
-  .withTemplate(require('./template.twig'));
+  .withFile(require('./template.twig'));


### PR DESCRIPTION
## Summary
- Use `withElementId` for shop content element
- Reference template file with `withFile`

## Testing
- `npm run build:dev` *(fails: sh: 1: webpack: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5caa60800832eaf4dad33fbb04684