### PR TITLE
Allow shop element in landingpage content dropzone

### DIFF
--- a/templates/landingpage/_layout.twig
+++ b/templates/landingpage/_layout.twig
@@ -21,7 +21,7 @@
                 {% include './../shared/content-elements/header-image/template.twig' %}
             {% endblock %}
         </div>
-        <div id="content" class="mb-4 flex-grow-1 d-flex flex-column" data-bsi-dropzone="content-dropzone-r5vJUs" data-bsi-dropzone-allowed-elements="col-one-l2ZclN col-two-ILRIL0 col-three-MEOl1p col-four-yFAGKM spacer-jarY9b html-VN5KXz">
+        <div id="content" class="mb-4 flex-grow-1 d-flex flex-column" data-bsi-dropzone="content-dropzone-r5vJUs" data-bsi-dropzone-allowed-elements="col-one-l2ZclN col-two-ILRIL0 col-three-MEOl1p col-four-yFAGKM spacer-jarY9b html-VN5KXz shop-UEyFnQ">
             {% block content %}
             {% endblock %}
         </div>


### PR DESCRIPTION
## Summary
- enable shop element `shop-UEyFnQ` in landing page content dropzone

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5d0f58200832e98f4389fc882f1ee