### PR TITLE
Wrap shop template in root element

### DIFF
--- a/templates/landingpage/content-elements/shop/template.twig
+++ b/templates/landingpage/content-elements/shop/template.twig
@@ -1,4 +1,4 @@
-<div data-bsi-element="shop-UEyFnQ">
+<div data-bsi-element="{{ elementId|default('shop-UEyFnQ') }}">
 <div id="floatingPoints"><p style="color: #fff;" id="remaining"></p></div>
 
 <div class="container">


### PR DESCRIPTION
## Summary
- wrap landing page shop template in root element with `data-bsi-element` and optional `elementId`

## Testing
- `npm run build:dev` *(fails: sh: 1: webpack: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d86d8080832ea5d8d7121e840974