### PR TITLE
chore: remove shop element from landingpage design

### DIFF
--- a/templates/landingpage/design.twig
+++ b/templates/landingpage/design.twig
@@ -2,6 +2,5 @@
 
 {% block content %}
     {% include '@bsi-cx/design-standard-library-web/content-elements/layout/col-one/template.twig' %}
-    {% include 'content-elements/shop/template.twig' %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- remove default shop element from landingpage design template

## Testing
- `npm run build:dev` *(fails: sh: 1: webpack: not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@bsi-cx%2fdesign-standard-library-web)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d9dff87c832ea426193a3db101b0