### PR TITLE
Add part configuration for shop content element

### DIFF
--- a/templates/landingpage/content-elements/shop/index.js
+++ b/templates/landingpage/content-elements/shop/index.js
@@ -3,4 +3,12 @@ const {cx} = require('@bsi-cx/design-build');
 module.exports = cx.contentElement
   .withElementId('shop-UEyFnQ')
   .withLabel('Shop')
+  .withParts(
+    cx.part.withPartId('product-list').withLabel('Produktliste'),
+    cx.part.withPartId('cart-heading').withLabel('Warenkorb-Überschrift'),
+    cx.part.withPartId('cart-empty-button').withLabel('Warenkorb leeren'),
+    cx.part.withPartId('point-warning').withLabel('Punktwarnung'),
+    cx.part.withPartId('lightbox-close-text').withLabel('Lightbox schließen'),
+    cx.part.withPartId('modal-ok-button').withLabel('OK-Schaltfläche')
+  )
   .withFile(require('./template.twig'));


### PR DESCRIPTION
## Summary
- add missing part definitions to shop content element

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:dev` *(fails: sh: 1: webpack: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ddc4d7c4832ebba5b107eb1b8e4e