### PR TITLE
refactor: use cx.part for shop content element

### DIFF
--- a/templates/landingpage/content-elements/shop/index.js
+++ b/templates/landingpage/content-elements/shop/index.js
@@ -1,14 +1,14 @@
-const {cx, part} = require('@bsi-cx/design-build');
+const { cx } = require('@bsi-cx/design-build');
 
 module.exports = cx.contentElement
   .withElementId('shop-UEyFnQ')
   .withLabel('Shop')
   .withParts(
-    part.withId('product-list').withLabel('Produktliste'),
-    part.withId('cart-heading').withLabel('Warenkorb-Überschrift'),
-    part.withId('cart-empty-button').withLabel('Warenkorb leeren'),
-    part.withId('point-warning').withLabel('Punktwarnung'),
-    part.withId('lightbox-close-text').withLabel('Lightbox schließen'),
-    part.withId('modal-ok-button').withLabel('OK-Schaltfläche')
+    cx.part.withId('product-list').withLabel('Produktliste'),
+    cx.part.withId('cart-heading').withLabel('Warenkorb-Überschrift'),
+    cx.part.withId('cart-empty-button').withLabel('Warenkorb leeren'),
+    cx.part.withId('point-warning').withLabel('Punktwarnung'),
+    cx.part.withId('lightbox-close-text').withLabel('Lightbox schließen'),
+    cx.part.withId('modal-ok-button').withLabel('OK-Schaltfläche')
   )
   .withFile(require('./template.twig'));


### PR DESCRIPTION
## Summary
- replace `part` import with `cx` only in shop element
- invoke `cx.part.withId` for all shop element parts

## Testing
- ⚠️ `npm run build:dev` (webpack: not found)

------
https://chatgpt.com/codex/tasks/task_e_68a5e767e0e8832ea0e0419fe622414c